### PR TITLE
Adding validation for service_name variable

### DIFF
--- a/github-workflow-roles/variables.tf
+++ b/github-workflow-roles/variables.tf
@@ -138,6 +138,10 @@ variable "service_name" {
   description = "List of services allowed to assume the role"
   type        = list(string)
   default     = []
+  validation {
+    condition     = can(regex("^[A-Za-z0-9.-]+\\.amazonaws\\.com$", var.service_name))
+    error_message = "The service_name variable must be in the format of *.amazonaws.com and can only contain letters, numbers, hyphens, and dots."
+  }
 }
 
 variable "service_trust_policy_controls" {


### PR DESCRIPTION
Added validation for service_name variable to ensure only service principals are passed

## Description (What did you change and why did you change it?)
Added validation to ensure users don't pass anything but service principal arns to service_name variable. Without validations users could pass any role/user arn and assume the role created for the service.

## Type(s)

- [ ] New Role
- [ ] Updated Role
- [ ] Workflow

## Ticket Number (if applicable)

## Acceptance

Check your PR for the following:

- [x] I am following the [Role Vending Workflow](README.md) outlined in this repo's README.md
- [x] I ran `terraform fmt` against my code
- [x] My commit message contains a concise description of the changes
