### PR TITLE
Minor fixes to generate providers workflow and break glass example

### DIFF
--- a/.github/workflows/generate_providers_and_account_vars.yml
+++ b/.github/workflows/generate_providers_and_account_vars.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Configure AWS Credentials for reading state
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: arn:aws:iam::${{ steps.dotenv.outputs.aws_account_id }}:role/github-workflow-rvm
+          role-to-assume: arn:aws:iam::${{ steps.dotenv.outputs.tf_var_rvm_account_id }}:role/github-workflow-rvm
           role-session-name: ${{ github.actor }}_${{ github.job }}
           aws-region: ${{ steps.dotenv.outputs.aws_region }}
 

--- a/examples/example-breakglass-role.tf
+++ b/examples/example-breakglass-role.tf
@@ -8,7 +8,7 @@ module "example-break-glass-PRD" {
   }
 
   # Specify the least permissions required for break glass access
-  inline_policy = data.aws_iam_policy_document.example-pod-identity_Production_permissions.json
+  inline_policy = data.aws_iam_policy_document.example-breakglass_Production_permissions.json
 
 
   rvm_account_id = var.rvm_account_id
@@ -23,7 +23,7 @@ module "example-break-glass-PRD" {
   role_name = "test-break-glass-role"
 }
 
-data "aws_iam_policy_document" "example-pod-identity_Production_permissions" {
+data "aws_iam_policy_document" "example-breakglass_Production_permissions" {
   # Specify the permissions that your workflow role needs using this resource
   statement {
     sid    = "CreateS3buckets"


### PR DESCRIPTION
## Description (What did you change and why did you change it?)
Updated the account variable in Generate Providers and Account Variables workflow to reflect changes to .env file.
Updated break glass example resource names to match the role type.

## Type(s)

- [ ] New Role
- [ ] Updated Role
- [x] Workflow

## Ticket Number (if applicable)

## Acceptance

Check your PR for the following:

- [x] I am following the [Role Vending Workflow](README.md) outlined in this repo's README.md
- [x] I ran `terraform fmt` against my code
- [x] My commit message contains a concise description of the changes
